### PR TITLE
Update video_handler.py

### DIFF
--- a/src/pupil_labs/egocentric_video_mapper/video_handler.py
+++ b/src/pupil_labs/egocentric_video_mapper/video_handler.py
@@ -45,6 +45,13 @@ class VideoHandler:
         vid_frame, self.lpts = get_frame(
             self.video_container, pts, self.lpts, self.last_frame
         )
+        if vid_frame is None:
+            logger.warning(
+                f"Frame {pts} not found in video, using last frame {self.lpts}"
+            )
+            vid_frame = self.last_frame
+
+        
         frame = vid_frame.to_ndarray(format="rgb24")
         self.last_frame = vid_frame
         self._read_frames += 1


### PR DESCRIPTION
Sometimes the final frame of a video from an alternative camera returns as empty/None. Implement a tiny, temporary fix